### PR TITLE
docs: add tags to links

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,16 @@ Ceci est une liste qui regroupe des ressources gratuites qui pourront vous être
 
 Chaque lien à sa place dans cette liste s'il peut aider un·e développeur·euse à découvrir le sujet en question.
 
+#### Tags
+
+Chaque lien peut être suffixé par un des 4 tags suivants afin de donner plus d'informations sur son contenu :
+- `Quoi` : le lien présente le concept, l'outil ou la méthodologie et explique ses fondements
+- `Pourquoi` : le lien explique dans quels cas un·e développeur·euse peut avoir besoin d'utiliser ce concept, cet outil ou cette méthodologie
+- `Comment` : le lien explique les bases nécessaires pour mettre en place ce concept, cet outil ou cette méthodologie
+- `Ressources` : le lien regroupe des ressources pour prendre en main ce concept, cet outil ou cette méthodologie
+
+Bien sûr un lien peut couvrir plusieurs tags à la fois, dans quel chaque tags sera ajouté à la suite du lien dans l'ordre du plus représenté au moins représenté.
+
 #### Contribuer au projet
 
 Vous pouvez contribuer à cette liste en créant une [Pull Request](https://github.com/Ldoppea/first-steps-dev) dans laquelle vous pourrez proposer un nouveau lien ou une nouvelle catégorie ou alors supprimer un lien qui ne serait plus actif.
@@ -23,27 +33,27 @@ Sommaire
 
 ## Architecture hexagonale
 
-- [Architecture hexagonale pour les nuls](https://www.youtube.com/watch?v=Hi5aDfRe-aE) [youtube.com]
-- [Architecture Hexagonale : Comment bien écrire ses tests ?](https://www.youtube.com/watch?v=4vBJAN3ttkc) [youtube.com]
+- [Architecture hexagonale pour les nuls](https://www.youtube.com/watch?v=Hi5aDfRe-aE) [youtube.com] → `Quoi` `Pourquoi` `Comment`
+- [Architecture Hexagonale : Comment bien écrire ses tests ?](https://www.youtube.com/watch?v=4vBJAN3ttkc) [youtube.com] → `Comment`
 
 ## State management
 
-- [Redux docs](https://redux.js.org/introduction/getting-started) [US]
-- [NgRx docs](https://ngrx.io/guide/store) [US]
-- [Vuex docs](https://vuex.vuejs.org/) [US]
+- [Redux docs](https://redux.js.org/introduction/getting-started) [US] → `Comment`
+- [NgRx docs](https://ngrx.io/guide/store) [US] → `Comment`
+- [Vuex docs](https://vuex.vuejs.org/) [US] → `Comment` `Quoi` `Pourquoi`
 
 ## Cloud
 
-- [12 factor app](https://12factor.net/fr/) [12factor.net]
+- [12 factor app](https://12factor.net/fr/) [12factor.net] → `Quoi` `Pourquoi`
 
 # DevOps
 
 ## Intégration continue (CI)
 
-- [Réussir ses mises en prod grâce à l'intégration continue](https://www.youtube.com/watch?v=70LqFphGmC8) [youtube.com]
-- [Pourquoi mettre en place de l'intégration continue](https://blog.soat.fr/2013/04/pourquoi-mettre-en-place-de-lintegration-continue/) [bloag.soat.fr]
-- [L'intégration continue : qu'est-ce que c'est ?](https://blog.axopen.com/2019/07/lintegration-continue-quest-ce-que-cest/) [blog.axopen.com]
-- [Awesome CI and CD](https://github.com/cicdops/awesome-ciandcd) [github.com][🇺🇸]
+- [Réussir ses mises en prod grâce à l'intégration continue](https://www.youtube.com/watch?v=70LqFphGmC8) [youtube.com] → `Quoi` `Pourquoi`
+- [Pourquoi mettre en place de l'intégration continue](https://blog.soat.fr/2013/04/pourquoi-mettre-en-place-de-lintegration-continue/) [bloag.soat.fr] → `Pourquoi`
+- [L'intégration continue : qu'est-ce que c'est ?](https://blog.axopen.com/2019/07/lintegration-continue-quest-ce-que-cest/) [blog.axopen.com] → `Quoi` `Pourquoi`
+- [Awesome CI and CD](https://github.com/cicdops/awesome-ciandcd) [github.com][🇺🇸] → `Ressources`
 
 ## Déploiement continu (CD)
 
@@ -53,26 +63,26 @@ Sommaire
 
 ## Accessibilité
 
-- [Qu'est ce que l'accessibilité?](https://developer.mozilla.org/fr/docs/Apprendre/a11y/What_is_accessibility) [developer.mozilla.org]
+- [Qu'est ce que l'accessibilité?](https://developer.mozilla.org/fr/docs/Apprendre/a11y/What_is_accessibility) [developer.mozilla.org] → `Quoi` `Pourquoi` `Comment`
 
 ## Domain Driven Design
 
-- [Introduction au Domain Driven Design](https://lesdieuxducode.com/blog/2019/7/introduction-au-domain-driven-design) [lesdieuxducode.com]
+- [Introduction au Domain Driven Design](https://lesdieuxducode.com/blog/2019/7/introduction-au-domain-driven-design) [lesdieuxducode.com] → `Quoi`
 
 # Gestion de projet / Agilité
 
 ## Retrospectives
 
-- [La rétrospective : qui ? quoi ? comment ?](https://blog.soat.fr/2018/12/retrospectives/) [blog.soat.fr]
+- [La rétrospective : qui ? quoi ? comment ?](https://blog.soat.fr/2018/12/retrospectives/) [blog.soat.fr] → `Quoi` `Pourquoi` `Comment`
 
 # Pratiques de développement
 
 ## Revue de code
 
-- [Principes et avantages de la revue de code](https://www.novaway.fr/blog/tech/principes-et-avantages-de-la-revue-de-code) [novaway.fr]
-- [Code review: comment faire une review constructive](https://practicalprogramming.fr/comment-faire-une-code-review/) [practicalprogramming.fr]
+- [Principes et avantages de la revue de code](https://www.novaway.fr/blog/tech/principes-et-avantages-de-la-revue-de-code) [novaway.fr] → `Quoi` `Pourquoi` `Comment`
+- [Code review: comment faire une review constructive](https://practicalprogramming.fr/comment-faire-une-code-review/) [practicalprogramming.fr] → `Comment`
 
 ## Test-Driven Development (TDD)
 
-- [TDD : pour que votre code soit testable et testé!](https://www.youtube.com/watch?v=EW98_rwUQec) [youtube.com]
+- [TDD : pour que votre code soit testable et testé!](https://www.youtube.com/watch?v=EW98_rwUQec) [youtube.com] → `Quoi` `Pourquoi` `Comment`
 


### PR DESCRIPTION
I tried a new way to categorize links.

The idea is to add some tags after each links to specify what can be found in those links : `What`, `Why`, `What`

Do you think it's a good idea? I'm not sure if this would fit all needs.

![image](https://user-images.githubusercontent.com/1884255/95518224-ee39c180-09c2-11eb-9a46-d6bad8b69d94.png)

Here is an example : 
![image](https://user-images.githubusercontent.com/1884255/95518260-001b6480-09c3-11eb-8073-eca77a74bc9b.png)

